### PR TITLE
Added methods to return coordinates of the square center point

### DIFF
--- a/maidenhead.go
+++ b/maidenhead.go
@@ -99,13 +99,14 @@ var parseLocatorMult = []struct {
 
 var maxLocatorLength = len(parseLocatorMult)
 
-func parseLocator(locator string, strict bool) (point Point, err error) {
+func parseLocator(locator string, strict bool, centered bool) (point Point, err error) {
 	var (
 		lnglat = [2]float64{
 			-180.0,
 			-90.0,
 		}
-		j int
+		i, j int
+		char rune
 	)
 
 	if len(locator) > maxLocatorLength {
@@ -120,7 +121,7 @@ func parseLocator(locator string, strict bool) (point Point, err error) {
 	}
 
 	if strict {
-		for i, char := range locator {
+		for i, char = range locator {
 			if j = strings.Index(parseLocatorMult[i].s, string(char)); j < 0 {
 				err = fmt.Errorf("maidenhead: invalid character at offset %d", i)
 				return
@@ -128,13 +129,18 @@ func parseLocator(locator string, strict bool) (point Point, err error) {
 			lnglat[i%2] += float64(j) * parseLocatorMult[i].mult
 		}
 	} else {
-		for i, char := range strings.ToLower(locator) {
+		for i, char = range strings.ToLower(locator) {
 			if j = strings.Index(parseLocatorMult[i].p, string(char)); j < 0 {
 				err = fmt.Errorf("maidenhead: invalid character at offset %d", i)
 				return
 			}
 			lnglat[i%2] += float64(j) * parseLocatorMult[i].mult
 		}
+	}
+
+	if centered {
+		lnglat[0] += parseLocatorMult[i-1].mult / 2.0
+		lnglat[1] += parseLocatorMult[i].mult / 2.0
 	}
 
 	point = NewPoint(lnglat[1], lnglat[0])

--- a/maidenhead_test.go
+++ b/maidenhead_test.go
@@ -1,6 +1,8 @@
 package maidenhead
 
-import "testing"
+import (
+	"testing"
+)
 
 var tests = []struct {
 	point Point
@@ -62,6 +64,31 @@ func TestParseInvalidLocatorStrict(t *testing.T) {
 			t.Errorf("Parsing invalid locator '%s' with ParseLocatorStrict() doesn't return any error", l)
 		} else {
 			t.Logf("Parsing invalid locator '%s' returns error: %s", l, err)
+		}
+	}
+}
+
+// Distance between corner point and center of the locator square
+func TestParseLocatorCentered(t *testing.T) {
+	tests := []struct {
+		loc          string
+		distExpected float64
+	}{
+		{"JN89", 91.42870273454076},
+		{"JN89HF", 3.8111046375990782},
+		{"JN89HF23", 0.38109528459829756},
+		{"JN89HF23ag", 0.015878904160500258},
+	}
+
+	for _, test := range tests {
+		p, _ := ParseLocator(test.loc)
+		pc, _ := ParseLocatorCentered(test.loc)
+
+		dist := pc.Distance(p)
+
+		if dist != test.distExpected {
+			t.Errorf("Distance between the center and corner of square locator '%s' is %g, expected %g",
+				test.loc, dist, test.distExpected)
 		}
 	}
 }

--- a/point.go
+++ b/point.go
@@ -33,12 +33,24 @@ func NewPoint(latitude, longitude float64) Point {
 
 // ParseLocator parses a Maidenhead Locator with permissive rule matching.
 func ParseLocator(locator string) (Point, error) {
-	return parseLocator(locator, false)
+	return parseLocator(locator, false, false)
 }
 
 // ParseLocatorStrict parses a Maidenhead Locator with strict rule matching.
 func ParseLocatorStrict(locator string) (Point, error) {
-	return parseLocator(locator, true)
+	return parseLocator(locator, true, false)
+}
+
+// ParseLocatorCentered parses a Maidenhead Locator with permissive rule matching.
+// Returns Points structure with coordinates of the square center
+func ParseLocatorCentered(locator string) (Point, error) {
+	return parseLocator(locator, false, true)
+}
+
+// ParseLocatorStrictCentered parses a Maidenhead Locator with strict rule matching.
+// Returns Points structure with coordinates of the square center
+func ParseLocatorStrictCentered(locator string) (Point, error) {
+	return parseLocator(locator, true, true)
 }
 
 func (p Point) EqualTo(other Point) bool {


### PR DESCRIPTION
It's quite common to require coordinates of the center of Maidenhead Square. Current functions `ParseLocator()` and `ParseLocatorStrict()` returns the corner of square. 

I have added new methods `ParseLocatorCentered()` and `ParseLocatorStrictCentered()` not to break backward compatibility of public API. These new methods move the result coordinates to the center of square instead of center. 
